### PR TITLE
deviceinfo: Add device name inside settings firmwareversion layout

### DIFF
--- a/res/values/voltage_strings.xml
+++ b/res/values/voltage_strings.xml
@@ -21,7 +21,10 @@
     <!-- VoltageOS maintainer -->
     <string name="maintainer">Maintainer</string>
     <string name="voltage_maintainer">Unofficial Maintainer</string>
-
+    
+    <!-- VoltageOS device -->
+    <string name="about_device_name">VoltageOS Device</string>
+    
     <!-- SELinux Status -->
     <string name="selinux_status">SELinux status</string>
     <string name="selinux_status_disabled">Disabled</string>

--- a/res/xml/firmware_version.xml
+++ b/res/xml/firmware_version.xml
@@ -43,6 +43,14 @@
         settings:enableCopying="true"
         settings:controller="com.android.settings.deviceinfo.firmwareversion.VoltageVersionPreferenceController"/>
 
+    <!-- VoltageOS Device -->
+    <Preference
+        android:key="about_device_name"
+        android:title="@string/about_device_name"
+        android:summary="@string/summary_placeholder"
+        settings:enableCopying="true"
+        settings:controller="com.android.settings.deviceinfo.firmwareversion.AboutDeviceNamePreferenceController"/>
+
     <!-- VoltageOS maintainer -->
     <Preference
         android:key="maintainer"

--- a/src/com/android/settings/deviceinfo/firmwareversion/AboutDeviceNamePreferenceController.java
+++ b/src/com/android/settings/deviceinfo/firmwareversion/AboutDeviceNamePreferenceController.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 ArrowOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.deviceinfo.firmwareversion;
+
+import android.content.Context;
+import android.os.SystemProperties;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+
+public class AboutDeviceNamePreferenceController extends BasePreferenceController {
+
+    private static final String TAG = "AboutDeviceNameCtrl";
+
+    private static final String KEY_DEVICE_NAME_PROP = "ro.product.device";
+
+    public AboutDeviceNamePreferenceController(Context context, String key) {
+        super(context, key);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        return SystemProperties.get(KEY_DEVICE_NAME_PROP,
+                mContext.getString(R.string.unknown));
+    }
+}


### PR DESCRIPTION
Squashed with the following:
Author: Adithya R <gh0strider.2k18.reborn@gmail.com>
Date:   Mon Nov 9 11:15:02 2020 +0530

    Settings: Read device codename from ro.product.device

     * On unified builds for devices with different codenames, init extension sets the
       appropriate codename. Display that codename instead of the one set at build time.

    Change-Id: I093414a79153323cff9140879ec582354861a1e7

Change-Id: I61fd4d77375df019da94ed7fca71da157dd0f415